### PR TITLE
Fix packaging layout for PyPI publication

### DIFF
--- a/experiments/cfair/config.yaml
+++ b/experiments/cfair/config.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: cfair10_basedist_comparison
 experiments:
     - &exp_laplace
-      __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+      __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
       name: mnist_laplace
       scheduler: &scheduler 
         __object__: ray.tune.schedulers.ASHAScheduler
@@ -18,7 +18,7 @@ experiments:
         mode: min
       trial_config:
         dataset: &dataset
-          __object__: src.cjd_flows.experiments.datasets.CfairSplit
+          __object__: cjd_flows.experiments.datasets.CfairSplit
           digit: 0
         epochs: &epochs 20000
         patience: &patience 50
@@ -34,7 +34,7 @@ experiments:
         
         model_cfg: 
           type:
-            __class__: &model src.cjd_flows.flows.NiceFlow
+            __class__: &model cjd_flows.flows.NiceFlow
           params:
             coupling_layers: &coupling_layers 
               __eval__: tune.choice([ 2, 3, 4, 5])

--- a/experiments/cifar/cifar.yaml
+++ b/experiments/cifar/cifar.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: fashion_ablation
 experiments:
   - &exp_rad_logN
-    __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+    __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
     name: cfair_full_radial_logN
     skip: true
     device: cpu
@@ -25,7 +25,7 @@ experiments:
         "image_shape": [28, 28]
       dataset: &dataset
         class:
-          __class__: src.cjd_flows.explib.datasets.Cifar10Split
+          __class__: cjd_flows.explib.datasets.Cifar10Split
         params:
           space_to_depth_factor: 4
           dataloc: /home/faried/Projects/USFlows/data/cifar10
@@ -36,7 +36,7 @@ experiments:
         __eval__: tune.choice([32])
       optim_cfg: &optim 
         optimizer:
-          __class__: src.cjd_flows.sophia.SophiaG
+          __class__: cjd_flows.sophia.SophiaG
         params:
           lr: 
             __eval__: 1e-3
@@ -44,7 +44,7 @@ experiments:
       
       model_cfg:
         type:
-          __class__: src.cjd_flows.flows.USFlow
+          __class__: cjd_flows.flows.USFlow
         params:
           soft_training: 
             __eval__: tune.choice([False])
@@ -59,7 +59,7 @@ experiments:
           lu_transform: 1
           householder: 0
           conditioner_cls:
-            __class__: src.cjd_flows.networks.ConvNet2D
+            __class__: cjd_flows.networks.ConvNet2D
           conditioner_args:
             c_in: 48
             c_hidden: 
@@ -78,14 +78,14 @@ experiments:
           nonlinearity:
             __eval__: tune.choice([torch.nn.ReLU()])
           base_distribution:
-            __object__: src.cjd_flows.distributions.RadialDistribution
+            __object__: cjd_flows.distributions.RadialDistribution
             device: cpu
             p: 
               __eval__: float("1")
             loc:
               __eval__: torch.zeros([48, 8, 8]).to("cpu")
             norm_distribution:
-              __object__: src.cjd_flows.distributions.LogNormal
+              __object__: cjd_flows.distributions.LogNormal
               loc:
                 __eval__: torch.ones([1]).to("cpu") * 6
               scale:

--- a/experiments/cifar/cifar_complementary.yaml
+++ b/experiments/cifar/cifar_complementary.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: fashion_ablation
 experiments:
   - &exp_rad_logN
-    __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+    __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
     name: cfair_full_radial_logN
     skip: true
     device: cuda
@@ -25,7 +25,7 @@ experiments:
         "image_shape": [28, 28]
       dataset: &dataset
         class:
-          __class__: src.cjd_flows.explib.datasets.Cifar10Split
+          __class__: cjd_flows.explib.datasets.Cifar10Split
         params:
           space_to_depth_factor: 4
           dataloc: /home/faried/Projects/USFlows/data/cifar10
@@ -36,7 +36,7 @@ experiments:
         __eval__: tune.choice([32])
       optim_cfg: &optim 
         optimizer:
-          __class__: src.cjd_flows.sophia.SophiaG
+          __class__: cjd_flows.sophia.SophiaG
         params:
           lr: 
             __eval__: 1e-3
@@ -44,7 +44,7 @@ experiments:
       
       model_cfg:
         type:
-          __class__: src.cjd_flows.flows.USFlow
+          __class__: cjd_flows.flows.USFlow
         params:
           soft_training: 
             __eval__: tune.choice([False])
@@ -59,7 +59,7 @@ experiments:
           lu_transform: 1
           householder: 0
           conditioner_cls:
-            __class__: src.cjd_flows.networks.ConvNet2D
+            __class__: cjd_flows.networks.ConvNet2D
           conditioner_args:
             c_in: 48
             c_hidden: 
@@ -97,14 +97,14 @@ experiments:
             affine_conjugation: false
             base_distribution:
               __exact__:
-                __object__: src.cjd_flows.distributions.RadialDistribution
+                __object__: cjd_flows.distributions.RadialDistribution
                 device: cuda
                 p: 
                   __eval__: float("1")
                 loc:
                   __eval__: torch.zeros([48, 8, 8]).to("cuda")
                 norm_distribution:
-                    __object__: src.cjd_flows.distributions.LogNormal
+                    __object__: cjd_flows.distributions.LogNormal
                     loc:
                       __eval__: torch.ones([1]).to("cuda") * 6
                     scale:

--- a/experiments/cifar/cifar_jet.yaml
+++ b/experiments/cifar/cifar_jet.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: cifar_jet
 experiments:
   - &exp_jet
-    __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+    __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
     name: cifar_jet_conditioner
     skip: false
     device: cuda
@@ -24,7 +24,7 @@ experiments:
         "image_shape": [28, 28]
       dataset: &dataset
         class:
-          __class__: src.cjd_flows.explib.datasets.Cifar10Split
+          __class__: cjd_flows.explib.datasets.Cifar10Split
         params:
           space_to_depth_factor: 4
           dataloc: /home/faried/Projects/USFlows/data/cifar10
@@ -35,7 +35,7 @@ experiments:
         __eval__: tune.choice([32])
       optim_cfg: &optim
         optimizer:
-          __class__: src.cjd_flows.sophia.SophiaG
+          __class__: cjd_flows.sophia.SophiaG
         params:
           lr:
             __eval__: 1e-4
@@ -43,7 +43,7 @@ experiments:
 
       model_cfg:
         type:
-          __class__: src.cjd_flows.flows.USFlow
+          __class__: cjd_flows.flows.USFlow
         params:
           soft_training:
             __eval__: tune.choice([False])
@@ -62,7 +62,7 @@ experiments:
           # couplings, as in the Jet architecture.
           masktype: channel
           conditioner_cls:
-            __class__: src.cjd_flows.networks.JetConditioner
+            __class__: cjd_flows.networks.JetConditioner
           conditioner_args:
             in_dims: [48, 8, 8]
             # space-to-depth already patchified the image; keep 8x8=64 tokens

--- a/experiments/fashion/config.yaml
+++ b/experiments/fashion/config.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: fashion_basedist_comparison
 experiments:
     - &exp_laplace
-      __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+      __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
       name: mnist_laplace
       scheduler: &scheduler 
         __object__: ray.tune.schedulers.ASHAScheduler
@@ -18,7 +18,7 @@ experiments:
         mode: min
       trial_config:
         dataset: &dataset
-          __object__: src.cjd_flows.explib.datasets.FashionMnistSplit
+          __object__: cjd_flows.explib.datasets.FashionMnistSplit
           label: 0
         epochs: &epochs 10000
         patience: &patience 500
@@ -34,7 +34,7 @@ experiments:
         
         model_cfg: 
           type:
-            __class__: &model src.cjd_flows.flows.NiceFlow
+            __class__: &model cjd_flows.flows.NiceFlow
           params:
             coupling_layers: &coupling_layers 
               __eval__: tune.choice([2, 3, 4, 6, 8])

--- a/experiments/fashion/fashion.yaml
+++ b/experiments/fashion/fashion.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: fashion_ablation
 experiments:
   - &exp_rad_logN
-    __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+    __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
     name: cfair_full_radial_logN
     skip: true
     device: cpu
@@ -25,7 +25,7 @@ experiments:
         "image_shape": [28, 28]
       dataset: &dataset
         class:
-          __class__: src.cjd_flows.explib.datasets.FashionMnistSplit
+          __class__: cjd_flows.explib.datasets.FashionMnistSplit
         params:
           space_to_depth_factor: 4
           dataloc: /home/faried/Projects/USFlows/data/fashion
@@ -36,7 +36,7 @@ experiments:
         __eval__: tune.choice([32])
       optim_cfg: &optim 
         optimizer:
-          __class__: src.cjd_flows.sophia.SophiaG
+          __class__: cjd_flows.sophia.SophiaG
         params:
           lr: 
             __eval__: 1e-3
@@ -44,7 +44,7 @@ experiments:
       
       model_cfg:
         type:
-          __class__: src.cjd_flows.flows.USFlow
+          __class__: cjd_flows.flows.USFlow
         params:
           soft_training: 
             __eval__: tune.choice([False])
@@ -59,7 +59,7 @@ experiments:
           lu_transform: 1
           householder: 0
           conditioner_cls:
-            __class__: src.cjd_flows.networks.ConvNet2D
+            __class__: cjd_flows.networks.ConvNet2D
           conditioner_args:
             c_in: 48
             c_hidden: 
@@ -78,14 +78,14 @@ experiments:
           nonlinearity:
             __eval__: tune.choice([torch.nn.ReLU()])
           base_distribution:
-            __object__: src.cjd_flows.distributions.RadialDistribution
+            __object__: cjd_flows.distributions.RadialDistribution
             device: cpu
             p: 
               __eval__: float("1")
             loc:
               __eval__: torch.zeros([48, 8, 8]).to("cpu")
             norm_distribution:
-              __object__: src.cjd_flows.distributions.LogNormal
+              __object__: cjd_flows.distributions.LogNormal
               loc:
                 __eval__: torch.ones([1]).to("cpu") * 6
               scale:

--- a/experiments/fashion/fashion_complementary.yaml
+++ b/experiments/fashion/fashion_complementary.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: fashion_ablation
 experiments:
   - &exp_rad_logN
-    __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+    __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
     name: cfair_full_radial_logN
     skip: true
     device: cuda
@@ -25,7 +25,7 @@ experiments:
         "image_shape": [28, 28]
       dataset: &dataset
         class:
-          __class__: src.cjd_flows.explib.datasets.FashionMnistSplit
+          __class__: cjd_flows.explib.datasets.FashionMnistSplit
         params:
           space_to_depth_factor: 4
           dataloc: /home/faried/Projects/USFlows/data/fashion
@@ -36,7 +36,7 @@ experiments:
         __eval__: tune.choice([32])
       optim_cfg: &optim 
         optimizer:
-          __class__: src.cjd_flows.sophia.SophiaG
+          __class__: cjd_flows.sophia.SophiaG
         params:
           lr: 
             __eval__: 1e-3
@@ -44,7 +44,7 @@ experiments:
       
       model_cfg:
         type:
-          __class__: src.cjd_flows.flows.USFlow
+          __class__: cjd_flows.flows.USFlow
         params:
           soft_training: 
             __eval__: tune.choice([False])
@@ -59,7 +59,7 @@ experiments:
           lu_transform: 1
           householder: 0
           conditioner_cls:
-            __class__: src.cjd_flows.networks.ConvNet2D
+            __class__: cjd_flows.networks.ConvNet2D
           conditioner_args:
             c_in: 48
             c_hidden: 
@@ -98,14 +98,14 @@ experiments:
             affine_conjugation: false
             base_distribution:
               __exact__: 
-                __object__: src.cjd_flows.distributions.RadialDistribution
+                __object__: cjd_flows.distributions.RadialDistribution
                 device: cuda
                 p: 
                   __eval__: float("1")
                 loc:
                   __eval__: torch.zeros([48, 8, 8]).to("cuda")
                 norm_distribution:
-                  __object__: src.cjd_flows.distributions.LogNormal
+                  __object__: cjd_flows.distributions.LogNormal
                   loc:
                     __eval__: torch.ones([1]).to("cuda") * 6
                   scale:

--- a/experiments/fashion/fashionclasses_macow.yaml
+++ b/experiments/fashion/fashionclasses_macow.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: fashion_ablation_macow
 experiments:
   - &exp_rad_logN
-    __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+    __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
     name: cfair_full_normal
     skip: false
     device: cpu
@@ -35,7 +35,7 @@ experiments:
         __eval__: tune.choice([32])
       optim_cfg: &optim 
         optimizer:
-          __class__: src.cjd_flows.sophia.SophiaG
+          __class__: cjd_flows.sophia.SophiaG
         params:
           lr: 
             __eval__: 1e-3
@@ -43,7 +43,7 @@ experiments:
       
       model_cfg:
         type:
-          __class__: src.cjd_flows.flows.USFlow
+          __class__: cjd_flows.flows.USFlow
         params:
           soft_training: 
             __eval__: tune.choice([False])
@@ -58,7 +58,7 @@ experiments:
           lu_transform: 1
           householder: 0
           conditioner_cls:
-            __class__: src.cjd_flows.networks.ConvNet2D
+            __class__: cjd_flows.networks.ConvNet2D
           conditioner_args:
             c_in: 16
             c_hidden: 

--- a/experiments/fashion/fashionclasses_macow_complementary.yaml
+++ b/experiments/fashion/fashionclasses_macow_complementary.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: fashion_ablation_macow
 experiments:
   - &exp_rad_logN
-    __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+    __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
     name: cfair_full_normal
     skip: false
     device: cuda
@@ -35,7 +35,7 @@ experiments:
         __eval__: tune.choice([32])
       optim_cfg: &optim 
         optimizer:
-          __class__: src.cjd_flows.sophia.SophiaG
+          __class__: cjd_flows.sophia.SophiaG
         params:
           lr: 
             __eval__: 1e-3
@@ -43,7 +43,7 @@ experiments:
       
       model_cfg:
         type:
-          __class__: src.cjd_flows.flows.USFlow
+          __class__: cjd_flows.flows.USFlow
         params:
           soft_training: 
             __eval__: tune.choice([False])
@@ -58,7 +58,7 @@ experiments:
           lu_transform: 1
           householder: 0
           conditioner_cls:
-            __class__: src.cjd_flows.networks.ConvNet2D
+            __class__: cjd_flows.networks.ConvNet2D
           conditioner_args:
             c_in: 16
             c_hidden: 
@@ -77,14 +77,14 @@ experiments:
           nonlinearity:
             __eval__: tune.choice([torch.nn.ReLU()])
           base_distribution:
-            __object__: src.cjd_flows.distributions.RadialDistribution
+            __object__: cjd_flows.distributions.RadialDistribution
             device: cuda
             p: 
               __eval__: float("1")
             loc:
               __eval__: torch.zeros([16, 7, 7]).to("cuda")
             norm_distribution:
-              __object__: src.cjd_flows.distributions.GammaMM
+              __object__: cjd_flows.distributions.GammaMM
               concentration:
                 __eval__: torch.rand([20]).to("cuda") * 75
               rate:

--- a/experiments/fashion/fashionclasses_veriflow.yaml
+++ b/experiments/fashion/fashionclasses_veriflow.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: fashion_ablation_veriflow
 experiments:
   - &exp_rad_logN
-    __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+    __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
     name: cfair_full_radial_logN
     skip: false
     device: cpu
@@ -24,7 +24,7 @@ experiments:
         "image_shape": [28, 28]
       dataset: &dataset
         class:
-          __class__: src.cjd_flows.explib.datasets.FashionMnistSplit
+          __class__: cjd_flows.explib.datasets.FashionMnistSplit
         params:
           space_to_depth_factor: 4
           dataloc: /home/faried/Projects/USFlows/data/fashion
@@ -35,7 +35,7 @@ experiments:
         __eval__: tune.choice([32])
       optim_cfg: &optim 
         optimizer:
-          __class__: src.cjd_flows.sophia.SophiaG
+          __class__: cjd_flows.sophia.SophiaG
         params:
           lr: 
             __eval__: 1e-3
@@ -43,7 +43,7 @@ experiments:
       
       model_cfg:
         type:
-          __class__: src.cjd_flows.flows.USFlow
+          __class__: cjd_flows.flows.USFlow
         params:
           soft_training: 
             __eval__: tune.choice([False])
@@ -58,7 +58,7 @@ experiments:
           lu_transform: 1
           householder: 0
           conditioner_cls:
-            __class__: src.cjd_flows.networks.ConvNet2D
+            __class__: cjd_flows.networks.ConvNet2D
           conditioner_args:
             c_in: 16
             c_hidden: 
@@ -77,14 +77,14 @@ experiments:
           nonlinearity:
             __eval__: tune.choice([torch.nn.ReLU()])
           base_distribution:
-            __object__: src.cjd_flows.distributions.RadialDistribution
+            __object__: cjd_flows.distributions.RadialDistribution
             device: cpu
             p: 
               __eval__: float("1")
             loc:
               __eval__: torch.zeros([16, 7, 7]).to("cpu")
             norm_distribution:
-              __object__: src.cjd_flows.distributions.GammaMM
+              __object__: cjd_flows.distributions.GammaMM
               concentration:
                 __eval__: torch.rand([20]).to("cpu") * 75
               rate:

--- a/experiments/fashion/fashionclasses_veriflow_complementary.yaml
+++ b/experiments/fashion/fashionclasses_veriflow_complementary.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: fashion_ablation_veriflow
 experiments:
   - &exp_rad_logN
-    __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+    __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
     name: cfair_full_radial_logN
     skip: false
     device: cuda
@@ -24,7 +24,7 @@ experiments:
         "image_shape": [28, 28]
       dataset: &dataset
         class:
-          __class__: src.cjd_flows.explib.datasets.FashionMnistSplit
+          __class__: cjd_flows.explib.datasets.FashionMnistSplit
         params:
           space_to_depth_factor: 4
           dataloc: /home/faried/Projects/USFlows/data/fashion
@@ -35,7 +35,7 @@ experiments:
         __eval__: tune.choice([32])
       optim_cfg: &optim 
         optimizer:
-          __class__: src.cjd_flows.sophia.SophiaG
+          __class__: cjd_flows.sophia.SophiaG
         params:
           lr: 
             __eval__: 1e-3
@@ -43,7 +43,7 @@ experiments:
       
       model_cfg:
         type:
-          __class__: src.cjd_flows.flows.USFlow
+          __class__: cjd_flows.flows.USFlow
         params:
           soft_training: 
             __eval__: tune.choice([False])
@@ -58,7 +58,7 @@ experiments:
           lu_transform: 1
           householder: 0
           conditioner_cls:
-            __class__: src.cjd_flows.networks.ConvNet2D
+            __class__: cjd_flows.networks.ConvNet2D
           conditioner_args:
             c_in: 16
             c_hidden: 

--- a/experiments/mnist/config_best.yaml
+++ b/experiments/mnist/config_best.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: mnist_basedist_comparison
 experiments:
     - &exp_laplace_best
-      __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+      __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
       name: mnist_normal_best
       scheduler: &scheduler 
         __object__: ray.tune.schedulers.ASHAScheduler
@@ -18,7 +18,7 @@ experiments:
         mode: min
       trial_config:
         dataset: &dataset
-          __object__: src.cjd_flows.explib.datasets.MnistSplit
+          __object__: cjd_flows.explib.datasets.MnistSplit
           digit: 0
         epochs: &epochs 10000
         patience: &patience 50
@@ -32,7 +32,7 @@ experiments:
         
         model_cfg: 
           type:
-            __class__: &model src.cjd_flows.flows.NiceFlow
+            __class__: &model cjd_flows.flows.NiceFlow
           params:
             coupling_layers: 4
             coupling_nn_layers: [50, 50]

--- a/experiments/mnist/config_lu.yaml
+++ b/experiments/mnist/config_lu.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.baseExperimentCollection
+__object__: cjd_flows.explib.baseExperimentCollection
 name: mnist_basedist_comparison
 experiments:
     - &exp_laplace
-      __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+      __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
       name: mnist_laplace
       scheduler: &scheduler 
         __object__: ray.tune.schedulers.ASHAScheduler
@@ -18,7 +18,7 @@ experiments:
         mode: min
       trial_config:
         dataset: &dataset
-          __object__: src.cjd_flows.explib.datasets.MnistSplit
+          __object__: cjd_flows.explib.datasets.MnistSplit
           digit: 0
         epochs: &epochs 20000
         patience: &patience 50
@@ -34,7 +34,7 @@ experiments:
         
         model_cfg: 
           type:
-            __class__: &model src.cjd_flows.flows.LUFlow
+            __class__: &model cjd_flows.flows.LUFlow
           params:
             n_layers: &n_layers 
               __eval__: tune.choice([ 2, 3, 4, 5, 6, 7, 8, 9, 10])

--- a/experiments/mnist/mnist.yaml
+++ b/experiments/mnist/mnist.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: mnist_ablation
 experiments:
   - &exp_rad_logN
-    __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+    __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
     name: mnist_full_radial_logN
     device: cpu
     skip: False
@@ -24,7 +24,7 @@ experiments:
         "image_shape": [28, 28]
       dataset: &dataset
         class: 
-          __class__: src.cjd_flows.explib.datasets.MnistSplit
+          __class__: cjd_flows.explib.datasets.MnistSplit
         params:
           dataloc: /home/faried/Projects/USFlows/data/mnist
           space_to_depth_factor: 4
@@ -35,7 +35,7 @@ experiments:
         __eval__: tune.choice([32])
       optim_cfg: 
         optimizer:
-          __class__: src.cjd_flows.sophia.SophiaG
+          __class__: cjd_flows.sophia.SophiaG
         params:
           lr: 
             __eval__: 1e-3
@@ -43,7 +43,7 @@ experiments:
       
       model_cfg:
         type:
-          __class__: src.cjd_flows.flows.USFlow
+          __class__: cjd_flows.flows.USFlow
         params:
           soft_training: 
             __eval__: tune.choice([False])
@@ -58,7 +58,7 @@ experiments:
           lu_transform: 1
           householder: 0
           conditioner_cls:
-            __class__: src.cjd_flows.networks.ConvNet2D
+            __class__: cjd_flows.networks.ConvNet2D
           conditioner_args:
             c_in: 16
             c_hidden: 
@@ -77,14 +77,14 @@ experiments:
           nonlinearity:
             __eval__: tune.choice([torch.nn.ReLU()])
           base_distribution:
-            __object__: src.cjd_flows.distributions.RadialDistribution
+            __object__: cjd_flows.distributions.RadialDistribution
             device: cpu
             p: 
               __eval__: float("1")
             loc:
               __eval__: torch.zeros([16, 7, 7]).to("cpu")
             norm_distribution:
-              __object__: src.cjd_flows.distributions.LogNormal
+              __object__: cjd_flows.distributions.LogNormal
               loc:
                 __eval__: torch.ones([1]).to("cpu") * 6
               scale:

--- a/experiments/mnist/mnist_0_minimal.yaml
+++ b/experiments/mnist/mnist_0_minimal.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: mnist_ablation
 experiments:
   - &exp_nice_lu_laplace
-    __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+    __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
     name: mnist_nice_lu_laplace
     scheduler: &scheduler 
       __object__: ray.tune.schedulers.ASHAScheduler
@@ -21,7 +21,7 @@ experiments:
         images: true
         "image_shape": [10, 10]
       dataset: &dataset
-        __object__: src.cjd_flows.explib.datasets.MnistSplit
+        __object__: cjd_flows.explib.datasets.MnistSplit
         digit: 0
         scale: true
       epochs: &epochs 200000
@@ -38,7 +38,7 @@ experiments:
       
       model_cfg: 
         type:
-          __class__: &model src.cjd_flows.flows.NiceFlow
+          __class__: &model cjd_flows.flows.NiceFlow
         params:
           masktype: alternate
           soft_training: false

--- a/experiments/mnist/mnist_complementary.yaml
+++ b/experiments/mnist/mnist_complementary.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: mnist_ablation
 experiments:
   - &exp_rad_logN
-    __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+    __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
     name: mnist_full_radial_logN
     device: cuda
     skip: False
@@ -24,7 +24,7 @@ experiments:
         "image_shape": [28, 28]
       dataset: &dataset
         class: 
-          __class__: src.cjd_flows.explib.datasets.MnistSplit
+          __class__: cjd_flows.explib.datasets.MnistSplit
         params:
           dataloc: /home/faried/Projects/USFlows/data/mnist
           space_to_depth_factor: 4
@@ -35,7 +35,7 @@ experiments:
         __eval__: tune.choice([32])
       optim_cfg: 
         optimizer:
-          __class__: src.cjd_flows.sophia.SophiaG
+          __class__: cjd_flows.sophia.SophiaG
         params:
           lr: 
             __eval__: 1e-3
@@ -43,7 +43,7 @@ experiments:
       
       model_cfg:
         type:
-          __class__: src.cjd_flows.flows.USFlow
+          __class__: cjd_flows.flows.USFlow
         params:
           soft_training: 
             __eval__: tune.choice([False])
@@ -58,7 +58,7 @@ experiments:
           lu_transform: 1
           householder: 0
           conditioner_cls:
-            __class__: src.cjd_flows.networks.ConvNet2D
+            __class__: cjd_flows.networks.ConvNet2D
           conditioner_args:
             c_in: 16
             c_hidden: 
@@ -97,14 +97,14 @@ experiments:
             affine_conjugation: false
             base_distribution:
               __exact__:
-                __object__: src.cjd_flows.distributions.RadialDistribution
+                __object__: cjd_flows.distributions.RadialDistribution
                 device: cuda
                 p: 
                   __eval__: float("1")
                 loc:
                   __eval__: torch.zeros([16, 7, 7]).to("cuda")
                 norm_distribution:
-                  __object__: src.cjd_flows.distributions.LogNormal
+                  __object__: cjd_flows.distributions.LogNormal
                   loc:
                     __eval__: torch.ones([1]).to("cuda") * 6
                   scale:

--- a/experiments/mnist/mnist_digits.yaml
+++ b/experiments/mnist/mnist_digits.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: mnist_gigits_logN
 experiments:
   - &exp_rad_logN
-    __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+    __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
     name: mnist0
     device: cpu
     skip: false
@@ -24,7 +24,7 @@ experiments:
         "image_shape": [28, 28]
       dataset: &dataset
         class: 
-          __class__: src.cjd_flows.explib.datasets.MnistSplit
+          __class__: cjd_flows.explib.datasets.MnistSplit
         params:
           dataloc: /home/faried/Projects/USFlows/data/mnist
           space_to_depth_factor: 4
@@ -36,7 +36,7 @@ experiments:
         __eval__: tune.choice([32])
       optim_cfg: 
         optimizer:
-          __class__: src.cjd_flows.sophia.SophiaG
+          __class__: cjd_flows.sophia.SophiaG
         params:
           lr: 
             __eval__: 1e-4
@@ -44,7 +44,7 @@ experiments:
       
       model_cfg:
         type:
-          __class__: src.cjd_flows.flows.USFlow
+          __class__: cjd_flows.flows.USFlow
         params:
           soft_training: 
             __eval__: tune.choice([False])
@@ -59,7 +59,7 @@ experiments:
           lu_transform: 1
           householder: 0
           conditioner_cls:
-            __class__: src.cjd_flows.networks.ConvNet2D
+            __class__: cjd_flows.networks.ConvNet2D
           conditioner_args:
             c_in: 16
             c_hidden: 
@@ -78,14 +78,14 @@ experiments:
           nonlinearity:
             __eval__: tune.choice([torch.nn.ReLU()])
           base_distribution:
-            __object__: src.cjd_flows.distributions.RadialDistribution
+            __object__: cjd_flows.distributions.RadialDistribution
             device: cpu
             p: 
               __eval__: float("1")
             loc:
               __eval__: torch.zeros([16, 7, 7]).to("cpu")
             norm_distribution:
-              __object__: src.cjd_flows.distributions.GammaMM
+              __object__: cjd_flows.distributions.GammaMM
               concentration:
                 __eval__: torch.rand([20]).to("cpu") * 75
               rate:

--- a/experiments/mnist/mnist_digits_complementary.yaml
+++ b/experiments/mnist/mnist_digits_complementary.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: mnist_gigits_logN
 experiments:
   - &exp_rad_logN
-    __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+    __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
     name: mnist0
     device: cuda
     skip: false
@@ -24,7 +24,7 @@ experiments:
         "image_shape": [28, 28]
       dataset: &dataset
         class: 
-          __class__: src.cjd_flows.explib.datasets.MnistSplit
+          __class__: cjd_flows.explib.datasets.MnistSplit
         params:
           dataloc: /home/faried/Projects/USFlows/data/mnist
           space_to_depth_factor: 4
@@ -36,7 +36,7 @@ experiments:
         __eval__: tune.choice([32])
       optim_cfg: 
         optimizer:
-          __class__: src.cjd_flows.sophia.SophiaG
+          __class__: cjd_flows.sophia.SophiaG
         params:
           lr: 
             __eval__: 1e-4
@@ -44,7 +44,7 @@ experiments:
       
       model_cfg:
         type:
-          __class__: src.cjd_flows.flows.USFlow
+          __class__: cjd_flows.flows.USFlow
         params:
           soft_training: 
             __eval__: tune.choice([False])
@@ -59,7 +59,7 @@ experiments:
           lu_transform: 1
           householder: 0
           conditioner_cls:
-            __class__: src.cjd_flows.networks.ConvNet2D
+            __class__: cjd_flows.networks.ConvNet2D
           conditioner_args:
             c_in: 16
             c_hidden: 

--- a/experiments/mnist/mnist_digits_macow_complementary.yaml
+++ b/experiments/mnist/mnist_digits_macow_complementary.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: mnist_gigits_logN
 experiments:
   - &exp_rad_logN
-    __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+    __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
     name: mnist0
     device: cuda
     skip: false
@@ -24,7 +24,7 @@ experiments:
         "image_shape": [28, 28]
       dataset: &dataset
         class: 
-          __class__: src.cjd_flows.explib.datasets.MnistSplit
+          __class__: cjd_flows.explib.datasets.MnistSplit
         params:
           dataloc: /home/faried/Projects/USFlows/data/mnist
           space_to_depth_factor: 4
@@ -36,7 +36,7 @@ experiments:
         __eval__: tune.choice([32])
       optim_cfg: 
         optimizer:
-          __class__: src.cjd_flows.sophia.SophiaG
+          __class__: cjd_flows.sophia.SophiaG
         params:
           lr: 
             __eval__: 1e-4
@@ -44,7 +44,7 @@ experiments:
       
       model_cfg:
         type:
-          __class__: src.cjd_flows.flows.USFlow
+          __class__: cjd_flows.flows.USFlow
         params:
           soft_training: 
             __eval__: tune.choice([False])
@@ -59,7 +59,7 @@ experiments:
           lu_transform: 0
           householder: 0
           conditioner_cls:
-            __class__: src.cjd_flows.networks.ConvNet2D
+            __class__: cjd_flows.networks.ConvNet2D
           conditioner_args:
             c_in: 16
             c_hidden: 
@@ -78,14 +78,14 @@ experiments:
           nonlinearity:
             __eval__: tune.choice([torch.nn.ReLU()])
           base_distribution:
-            __object__: src.cjd_flows.distributions.RadialDistribution
+            __object__: cjd_flows.distributions.RadialDistribution
             device: cuda
             p: 
               __eval__: float("1")
             loc:
               __eval__: torch.zeros([16, 7, 7]).to("cuda")
             norm_distribution:
-              __object__: src.cjd_flows.distributions.GammaMM
+              __object__: cjd_flows.distributions.GammaMM
               concentration:
                 __eval__: torch.rand([20]).to("cuda") * 75
               rate:

--- a/experiments/mnist/mnist_digits_minimal.yaml
+++ b/experiments/mnist/mnist_digits_minimal.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: mnist_digit_scaled_small_models
 experiments:
   - &exp_nice_lu_laplace
-    __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+    __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
     name: mnist_0
     scheduler:  
       __object__: ray.tune.schedulers.ASHAScheduler
@@ -21,7 +21,7 @@ experiments:
         images: true
         "image_shape": [10, 10]
       dataset: 
-        __object__: src.cjd_flows.explib.datasets.MnistSplit
+        __object__: cjd_flows.explib.datasets.MnistSplit
         digit: 0
         scale: true
       epochs:  200000
@@ -37,7 +37,7 @@ experiments:
           weight_decay: 0.0
       model_cfg: 
         type:
-          __class__:  src.cjd_flows.flows.NiceFlow
+          __class__:  cjd_flows.flows.NiceFlow
         params:
           masktype: alternate
           soft_training: false
@@ -65,62 +65,62 @@ experiments:
     name: mnist_1
     trial_config:
       dataset:
-        __object__: src.cjd_flows.explib.datasets.MnistSplit
+        __object__: cjd_flows.explib.datasets.MnistSplit
         digit: 1
         scale: true
   - __overwrites__: *exp_nice_lu_laplace
     name: mnist_2
     trial_config:
       dataset:
-        __object__: src.cjd_flows.explib.datasets.MnistSplit
+        __object__: cjd_flows.explib.datasets.MnistSplit
         digit: 2
         scale: true
   - __overwrites__: *exp_nice_lu_laplace
     name: mnist_3
     trial_config:
       dataset: 
-        __object__: src.cjd_flows.explib.datasets.MnistSplit
+        __object__: cjd_flows.explib.datasets.MnistSplit
         digit: 3
         scale: true
   - __overwrites__: *exp_nice_lu_laplace  
     name: mnist_4
     trial_config:
       dataset: 
-        __object__: src.cjd_flows.explib.datasets.MnistSplit
+        __object__: cjd_flows.explib.datasets.MnistSplit
         digit: 4
         scale: true
   - __overwrites__: *exp_nice_lu_laplace
     name: mnist_5
     trial_config:
       dataset: 
-        __object__: src.cjd_flows.explib.datasets.MnistSplit
+        __object__: cjd_flows.explib.datasets.MnistSplit
         digit: 5
         scale: true
   - __overwrites__: *exp_nice_lu_laplace
     name: mnist_6
     trial_config:
       dataset:
-        __object__: src.cjd_flows.explib.datasets.MnistSplit
+        __object__: cjd_flows.explib.datasets.MnistSplit
         digit: 6
         scale: true
   - __overwrites__: *exp_nice_lu_laplace
     name: mnist_7
     trial_config:
       dataset: 
-        __object__: src.cjd_flows.explib.datasets.MnistSplit
+        __object__: cjd_flows.explib.datasets.MnistSplit
         digit: 7
         scale: true
   - __overwrites__: *exp_nice_lu_laplace
     name: mnist_8
     trial_config:
       dataset: 
-        __object__: src.cjd_flows.explib.datasets.MnistSplit
+        __object__: cjd_flows.explib.datasets.MnistSplit
         digit: 8
         scale: true
   - __overwrites__: *exp_nice_lu_laplace
     name: mnist_9
     trial_config:
       dataset: 
-        __object__: src.cjd_flows.explib.datasets.MnistSplit
+        __object__: cjd_flows.explib.datasets.MnistSplit
         digit: 9
         scale: true

--- a/experiments/mnist/mnist_digits_minimal_radial_chi.yaml
+++ b/experiments/mnist/mnist_digits_minimal_radial_chi.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: mnist_digit_scaled_small_models_l1rad
 experiments:
   - &exp_nice_lu_laplace
-    __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+    __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
     name: mnist_0_chi_2.0
     scheduler:  
       __object__: ray.tune.schedulers.ASHAScheduler
@@ -21,7 +21,7 @@ experiments:
         images: true
         "image_shape": [10, 10]
       dataset: 
-        __object__: src.cjd_flows.explib.datasets.MnistSplit
+        __object__: cjd_flows.explib.datasets.MnistSplit
         digit: 0
         scale: true
       epochs:  200000
@@ -37,7 +37,7 @@ experiments:
           weight_decay: 0.0
       model_cfg: 
         type:
-          __class__:  src.cjd_flows.flows.NiceFlow
+          __class__:  cjd_flows.flows.NiceFlow
         params:
           masktype: alternate
           soft_training: false
@@ -55,12 +55,12 @@ experiments:
           split_dim: 
             __eval__: tune.choice([10 + i for i in range(41)])
           base_distribution: 
-            __object__: src.cjd_flows.distributions.RadialDistribution       
+            __object__: cjd_flows.distributions.RadialDistribution       
             p: 1.0
             loc: 
               __eval__: torch.zeros(100).to("cpu")
             radial_distribution:
-              __object__: src.cjd_flows.distributions.Chi
+              __object__: cjd_flows.distributions.Chi
               df: 
                 __eval__: torch.Tensor([2.0])
           use_lu: true
@@ -71,12 +71,12 @@ experiments:
         params:
           base_distribution:
             __exact__: 
-              __object__: src.cjd_flows.distributions.RadialDistribution       
+              __object__: cjd_flows.distributions.RadialDistribution       
               p: 1.0
               loc: 
                 __eval__: torch.zeros(100).to("cpu")
               radial_distribution:
-                __object__: src.cjd_flows.distributions.Chi
+                __object__: cjd_flows.distributions.Chi
                 df: 
                   __eval__: torch.Tensor([1.0])
   - __overwrites__: *exp_nice_lu_laplace
@@ -86,12 +86,12 @@ experiments:
         params:
           base_distribution:
             __exact__: 
-              __object__: src.cjd_flows.distributions.RadialDistribution       
+              __object__: cjd_flows.distributions.RadialDistribution       
               p: 1.0
               loc: 
                 __eval__: torch.zeros(100).to("cpu")
               radial_distribution:
-                __object__: src.cjd_flows.distributions.Chi
+                __object__: cjd_flows.distributions.Chi
                 df: 
                   __eval__: torch.Tensor([3.0])
   - __overwrites__: *exp_nice_lu_laplace
@@ -101,11 +101,11 @@ experiments:
         params:
           base_distribution:
             __exact__: 
-              __object__: src.cjd_flows.distributions.RadialDistribution       
+              __object__: cjd_flows.distributions.RadialDistribution       
               p: 1.0
               loc: 
                 __eval__: torch.zeros(100).to("cpu")
               radial_distribution:
-                __object__: src.cjd_flows.distributions.Chi
+                __object__: cjd_flows.distributions.Chi
                 df: 
                   __eval__: torch.Tensor([4.0])

--- a/experiments/mnist/mnist_digits_minimal_radial_chi2.yaml
+++ b/experiments/mnist/mnist_digits_minimal_radial_chi2.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: mnist_digit_scaled_small_models_l1rad
 experiments:
   - &exp_nice_lu_laplace
-    __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+    __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
     name: mnist_0_chi2_1
     scheduler:  
       __object__: ray.tune.schedulers.ASHAScheduler
@@ -21,7 +21,7 @@ experiments:
         images: true
         "image_shape": [10, 10]
       dataset: 
-        __object__: src.cjd_flows.explib.datasets.MnistSplit
+        __object__: cjd_flows.explib.datasets.MnistSplit
         digit: 0
         scale: true
       epochs:  200000
@@ -37,7 +37,7 @@ experiments:
           weight_decay: 0.0
       model_cfg: 
         type:
-          __class__:  src.cjd_flows.flows.NiceFlow
+          __class__:  cjd_flows.flows.NiceFlow
         params:
           masktype: alternate
           soft_training: false
@@ -55,7 +55,7 @@ experiments:
           split_dim: 
             __eval__: tune.choice([10 + i for i in range(41)])
           base_distribution: 
-            __object__: src.cjd_flows.distributions.RadialDistribution       
+            __object__: cjd_flows.distributions.RadialDistribution       
             p: 1.0
             loc: 
               __eval__: torch.zeros(100).to("cpu")
@@ -70,7 +70,7 @@ experiments:
         params:
           base_distribution:
             __exact__: 
-              __object__: src.cjd_flows.distributions.RadialDistribution       
+              __object__: cjd_flows.distributions.RadialDistribution       
               p: 1.0
               loc: 
                 __eval__: torch.zeros(100).to("cpu")
@@ -84,7 +84,7 @@ experiments:
         params:
           base_distribution:
             __exact__: 
-              __object__: src.cjd_flows.distributions.RadialDistribution       
+              __object__: cjd_flows.distributions.RadialDistribution       
               p: 1.0
               loc: 
                 __eval__: torch.zeros(100).to("cpu")
@@ -98,7 +98,7 @@ experiments:
         params:
           base_distribution:
             __exact__: 
-              __object__: src.cjd_flows.distributions.RadialDistribution       
+              __object__: cjd_flows.distributions.RadialDistribution       
               p: 1.0
               loc: 
                 __eval__: torch.zeros(100).to("cpu")

--- a/experiments/mnist/mnist_digits_minimal_radial_exponential.yaml
+++ b/experiments/mnist/mnist_digits_minimal_radial_exponential.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: mnist_digit_scaled_small_models_l1rad
 experiments:
   - &exp_nice_lu_laplace
-    __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+    __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
     name: mnist_0_logN_0.75
     scheduler:  
       __object__: ray.tune.schedulers.ASHAScheduler
@@ -21,7 +21,7 @@ experiments:
         images: true
         "image_shape": [10, 10]
       dataset: 
-        __object__: src.cjd_flows.explib.datasets.MnistSplit
+        __object__: cjd_flows.explib.datasets.MnistSplit
         digit: 0
         scale: true
       epochs:  200000
@@ -37,7 +37,7 @@ experiments:
           weight_decay: 0.0
       model_cfg: 
         type:
-          __class__:  src.cjd_flows.flows.NiceFlow
+          __class__:  cjd_flows.flows.NiceFlow
         params:
           masktype: alternate
           soft_training: false
@@ -55,7 +55,7 @@ experiments:
           split_dim: 
             __eval__: tune.choice([10 + i for i in range(41)])
           base_distribution: 
-            __object__: src.cjd_flows.distributions.RadialDistribution       
+            __object__: cjd_flows.distributions.RadialDistribution       
             p: 1.0
             loc: 
               __eval__: torch.zeros(100).to("cpu")
@@ -71,7 +71,7 @@ experiments:
         params:
           base_distribution:
             __exact__: 
-              __object__: src.cjd_flows.distributions.RadialDistribution       
+              __object__: cjd_flows.distributions.RadialDistribution       
               p: 1.0
               loc: 
                 __eval__: torch.zeros(100).to("cpu")

--- a/experiments/mnist/mnist_digits_minimal_radial_logN.yaml
+++ b/experiments/mnist/mnist_digits_minimal_radial_logN.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: mnist_digit_scaled_small_models_l1rad
 experiments:
   - &exp_nice_lu_laplace
-    __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+    __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
     name: mnist_0_logN_0.75
     scheduler:  
       __object__: ray.tune.schedulers.ASHAScheduler
@@ -21,7 +21,7 @@ experiments:
         images: true
         "image_shape": [10, 10]
       dataset: 
-        __object__: src.cjd_flows.explib.datasets.MnistSplit
+        __object__: cjd_flows.explib.datasets.MnistSplit
         digit: 0
         scale: true
       epochs:  200000
@@ -37,7 +37,7 @@ experiments:
           weight_decay: 0.0
       model_cfg: 
         type:
-          __class__:  src.cjd_flows.flows.NiceFlow
+          __class__:  cjd_flows.flows.NiceFlow
         params:
           masktype: alternate
           soft_training: false
@@ -55,7 +55,7 @@ experiments:
           split_dim: 
             __eval__: tune.choice([10 + i for i in range(41)])
           base_distribution: 
-            __object__: src.cjd_flows.distributions.RadialDistribution       
+            __object__: cjd_flows.distributions.RadialDistribution       
             p: 1.0
             loc: 
               __eval__: torch.zeros(100).to("cpu")
@@ -73,7 +73,7 @@ experiments:
         params:
           base_distribution:
             __exact__: 
-              __object__: src.cjd_flows.distributions.RadialDistribution       
+              __object__: cjd_flows.distributions.RadialDistribution       
               p: 1.0
               loc: 
                 __eval__: torch.zeros(100).to("cpu")

--- a/experiments/mnist/mnist_digits_minimal_radial_weilbul.yaml
+++ b/experiments/mnist/mnist_digits_minimal_radial_weilbul.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: mnist_digit_scaled_small_models_l1rad
 experiments:
   - &exp_nice_lu_laplace
-    __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+    __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
     name: mnist_0_weilbull_1.0
     scheduler:  
       __object__: ray.tune.schedulers.ASHAScheduler
@@ -21,7 +21,7 @@ experiments:
         images: true
         "image_shape": [10, 10]
       dataset: 
-        __object__: src.cjd_flows.explib.datasets.MnistSplit
+        __object__: cjd_flows.explib.datasets.MnistSplit
         digit: 0
         scale: true
       epochs:  200000
@@ -37,7 +37,7 @@ experiments:
           weight_decay: 0.0
       model_cfg: 
         type:
-          __class__:  src.cjd_flows.flows.NiceFlow
+          __class__:  cjd_flows.flows.NiceFlow
         params:
           masktype: alternate
           soft_training: false
@@ -55,7 +55,7 @@ experiments:
           split_dim: 
             __eval__: tune.choice([10 + i for i in range(41)])
           base_distribution: 
-            __object__: src.cjd_flows.distributions.RadialDistribution       
+            __object__: cjd_flows.distributions.RadialDistribution       
             p: 1.0
             loc: 
               __eval__: torch.zeros(100).to("cpu")
@@ -72,7 +72,7 @@ experiments:
         params:
           base_distribution:
             __exact__: 
-              __object__: src.cjd_flows.distributions.RadialDistribution       
+              __object__: cjd_flows.distributions.RadialDistribution       
               p: 1.0
               loc: 
                 __eval__: torch.zeros(100).to("cpu")
@@ -88,7 +88,7 @@ experiments:
         params:
           base_distribution:
             __exact__: 
-              __object__: src.cjd_flows.distributions.RadialDistribution       
+              __object__: cjd_flows.distributions.RadialDistribution       
               p: 1.0
               loc: 
                 __eval__: torch.zeros(100).to("cpu")
@@ -104,7 +104,7 @@ experiments:
         params:
           base_distribution:
             __exact__: 
-              __object__: src.cjd_flows.distributions.RadialDistribution       
+              __object__: cjd_flows.distributions.RadialDistribution       
               p: 1.0
               loc: 
                 __eval__: torch.zeros(100).to("cpu")
@@ -120,7 +120,7 @@ experiments:
         params:
           base_distribution:
             __exact__: 
-              __object__: src.cjd_flows.distributions.RadialDistribution       
+              __object__: cjd_flows.distributions.RadialDistribution       
               p: 1.0
               loc: 
                 __eval__: torch.zeros(100).to("cpu")
@@ -136,7 +136,7 @@ experiments:
         params:
           base_distribution:
             __exact__: 
-              __object__: src.cjd_flows.distributions.RadialDistribution       
+              __object__: cjd_flows.distributions.RadialDistribution       
               p: 1.0
               loc: 
                 __eval__: torch.zeros(100).to("cpu")
@@ -152,7 +152,7 @@ experiments:
         params:
           base_distribution:
             __exact__: 
-              __object__: src.cjd_flows.distributions.RadialDistribution       
+              __object__: cjd_flows.distributions.RadialDistribution       
               p: 1.0
               loc: 
                 __eval__: torch.zeros(100).to("cpu")
@@ -168,7 +168,7 @@ experiments:
         params:
           base_distribution:
             __exact__: 
-              __object__: src.cjd_flows.distributions.RadialDistribution       
+              __object__: cjd_flows.distributions.RadialDistribution       
               p: 1.0
               loc: 
                 __eval__: torch.zeros(100).to("cpu")
@@ -184,7 +184,7 @@ experiments:
         params:
           base_distribution:
             __exact__: 
-              __object__: src.cjd_flows.distributions.RadialDistribution       
+              __object__: cjd_flows.distributions.RadialDistribution       
               p: 1.0
               loc: 
                 __eval__: torch.zeros(100).to("cpu")

--- a/experiments/mnist/mnist_digits_minimal_radialdists.yaml
+++ b/experiments/mnist/mnist_digits_minimal_radialdists.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: mnist_digit_scaled_small_models_l1rad
 experiments:
   - &exp_nice_lu_laplace
-    __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+    __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
     name: mnist_0_logN
     scheduler:  
       __object__: ray.tune.schedulers.ASHAScheduler
@@ -21,7 +21,7 @@ experiments:
         images: true
         "image_shape": [10, 10]
       dataset: 
-        __object__: src.cjd_flows.explib.datasets.MnistSplit
+        __object__: cjd_flows.explib.datasets.MnistSplit
         digit: 0
         scale: true
       epochs:  200000
@@ -37,7 +37,7 @@ experiments:
           weight_decay: 0.0
       model_cfg: 
         type:
-          __class__:  src.cjd_flows.flows.NiceFlow
+          __class__:  cjd_flows.flows.NiceFlow
         params:
           masktype: alternate
           soft_training: false
@@ -55,7 +55,7 @@ experiments:
           split_dim: 
             __eval__: tune.choice([10 + i for i in range(41)])
           base_distribution: 
-            __object__: src.cjd_flows.distributions.RadialDistribution       
+            __object__: cjd_flows.distributions.RadialDistribution       
             p: 1.0
             loc: 
               __eval__: torch.zeros(100).to("cpu")
@@ -73,7 +73,7 @@ experiments:
         params:
           base_distribution:
             __exact__: 
-              __object__: src.cjd_flows.distributions.RadialDistribution       
+              __object__: cjd_flows.distributions.RadialDistribution       
               p: 1.0
               loc: 
                 __eval__: torch.zeros(100).to("cpu")
@@ -87,7 +87,7 @@ experiments:
         params:
           base_distribution:
             __exact__: 
-              __object__: src.cjd_flows.distributions.RadialDistribution       
+              __object__: cjd_flows.distributions.RadialDistribution       
               p: 1.0
               loc: 
                 __eval__: torch.zeros(100).to("cpu")

--- a/experiments/mnist/mnist_usflow.yaml
+++ b/experiments/mnist/mnist_usflow.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: mnist_ablation
 experiments:
   - &exp_laplace
-    __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+    __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
     name: mnist_full_radial_logN
     scheduler: &scheduler 
       __object__: ray.tune.schedulers.ASHAScheduler
@@ -22,7 +22,7 @@ experiments:
         images: false
         "image_shape": [28, 28]
       dataset: &dataset
-        __object__: src.cjd_flows.explib.datasets.MnistSplit
+        __object__: cjd_flows.explib.datasets.MnistSplit
         space_to_depth_factor: 2
         device: cuda 
       epochs: &epochs 200000
@@ -39,7 +39,7 @@ experiments:
       
       model_cfg: 
         type:
-          __class__: &model src.cjd_flows.flows.USFlow
+          __class__: &model cjd_flows.flows.USFlow
         params:
           soft_training: false
           training_noise_prior:
@@ -50,7 +50,7 @@ experiments:
           prior_scale: 1.0
           coupling_blocks: 1
           conditioner_cls: 
-            __class__: src.cjd_flows.networks.ConvNet2D
+            __class__: cjd_flows.networks.ConvNet2D
           conditioner_args:
             c_in: 4
             num_layers: 3

--- a/experiments/mnist/mnist_usflow_cpu.yaml
+++ b/experiments/mnist/mnist_usflow_cpu.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: mnist_ablation
 experiments:
   - &exp_laplace0
-    __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+    __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
     name: mnist0
     scheduler:  
       __object__: ray.tune.schedulers.ASHAScheduler
@@ -22,7 +22,7 @@ experiments:
         images: false
         image_shape: [28, 28]
       dataset: 
-        __object__: src.cjd_flows.explib.datasets.MnistSplit
+        __object__: cjd_flows.explib.datasets.MnistSplit
         space_to_depth_factor: 4
         device: cpu 
         digit: 0
@@ -40,7 +40,7 @@ experiments:
       
       model_cfg: 
         type:
-          __class__: src.cjd_flows.flows.USFlow
+          __class__: cjd_flows.flows.USFlow
         params:
           soft_training: true
           training_noise_prior:
@@ -53,7 +53,7 @@ experiments:
           lu_transform: 1
           householder: 0
           conditioner_cls: 
-            __class__: src.cjd_flows.networks.CondConvNet2D
+            __class__: cjd_flows.networks.CondConvNet2D
           conditioner_args:
             c_in: 16
             c_hidden: 32
@@ -66,7 +66,7 @@ experiments:
           nonlinearity: 
             __eval__: tune.choice([torch.nn.ReLU()])
           base_distribution: 
-            __object__: src.cjd_flows.distributions.Laplace
+            __object__: cjd_flows.distributions.Laplace
             loc: 
               __eval__: torch.zeros([16, 7, 7]).to("cpu")
             scale: 

--- a/experiments/mnist/mnist_usflow_cpu_gammamm.yaml
+++ b/experiments/mnist/mnist_usflow_cpu_gammamm.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: mnist_ablation
 experiments:
   - &exp_laplace0
-    __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+    __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
     name: mnist0
     scheduler:  
       __object__: ray.tune.schedulers.ASHAScheduler
@@ -25,7 +25,7 @@ experiments:
         image_shape: [28, 28]
       dataset:
         class:
-          __class__: src.cjd_flows.explib.datasets.MnistSplit
+          __class__: cjd_flows.explib.datasets.MnistSplit
         params:
           dataloc: /Users/fariedabuzaid/Projects/veriflow/data
           space_to_depth_factor: 4
@@ -35,14 +35,14 @@ experiments:
         __eval__: tune.choice([32])
       optim_cfg: 
         optimizer:
-          __class__: src.cjd_flows.sophia.SophiaG 
+          __class__: cjd_flows.sophia.SophiaG 
         params:
           lr: 
             __eval__: 1e-4
           weight_decay: 0.0
       model_cfg: 
         type:
-          __class__: src.cjd_flows.flows.USFlow
+          __class__: cjd_flows.flows.USFlow
         params:
           soft_training: false
           training_noise_prior:
@@ -55,7 +55,7 @@ experiments:
           lu_transform: 1
           householder: 0
           conditioner_cls: 
-            __class__: src.cjd_flows.networks.ConvNet2D
+            __class__: cjd_flows.networks.ConvNet2D
           conditioner_args:
             c_in: 16
             c_hidden: 32
@@ -73,7 +73,7 @@ experiments:
             __eval__: tune.choice([torch.nn.ReLU()])
           base_distribution: 
             class:
-              __class__: src.cjd_flows.distributions.RadialMM
+              __class__: cjd_flows.distributions.RadialMM
             params:      
               device: cpu
               p: 2.0
@@ -81,7 +81,7 @@ experiments:
                 __eval__: torch.randn([20, 16, 7, 7]).to("cpu") * 0.1
               norm_distribution:
                 class:
-                  __class__: src.cjd_flows.distributions.LogNormal
+                  __class__: cjd_flows.distributions.LogNormal
                 params:
                   loc: 
                     __eval__: torch.ones([20, 1, 1, 1]).to("cpu") * 1

--- a/experiments/mnist/mnist_usflow_gpu.yaml
+++ b/experiments/mnist/mnist_usflow_gpu.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: mnist_ablation
 experiments:
   - &exp_laplace
-    __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+    __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
     name: mnist_full_laplace
     scheduler:  
       __object__: ray.tune.schedulers.ASHAScheduler
@@ -22,7 +22,7 @@ experiments:
         images: false
         image_shape: [28, 28]
       dataset: 
-        __object__: src.cjd_flows.explib.datasets.MnistSplit
+        __object__: cjd_flows.explib.datasets.MnistSplit
         space_to_depth_factor: 2
         device: cuda  # Options: [cpu, cuda] 
       epochs:  200000
@@ -39,7 +39,7 @@ experiments:
       
       model_cfg: 
         type:
-          __class__: src.cjd_flows.flows.USFlow
+          __class__: cjd_flows.flows.USFlow
         params:
           soft_training: false
           training_noise_prior:
@@ -52,7 +52,7 @@ experiments:
           lu_transform: 1
           householder: 1
           conditioner_cls: 
-            __class__: src.cjd_flows.networks.ConvNet2D
+            __class__: cjd_flows.networks.ConvNet2D
           conditioner_args:
             c_in: 4
             num_layers: 4

--- a/experiments/mnist/mnist_usflow_hyperopt.yaml
+++ b/experiments/mnist/mnist_usflow_hyperopt.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: mnist_ablation
 experiments:
   - &exp_laplace
-    __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+    __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
     name: mnist_full_laplace
     scheduler:  
       __object__: ray.tune.schedulers.ASHAScheduler
@@ -22,7 +22,7 @@ experiments:
         images: false
         image_shape: [28, 28]
       dataset: 
-        __object__: src.cjd_flows.explib.datasets.MnistSplit
+        __object__: cjd_flows.explib.datasets.MnistSplit
         space_to_depth_factor: 4
         digit: 3
         device: cuda 
@@ -39,7 +39,7 @@ experiments:
           weight_decay: 0.0
       model_cfg: 
         type:
-          __class__: src.cjd_flows.flows.USFlow
+          __class__: cjd_flows.flows.USFlow
         params:
           soft_training: true
           in_dims: [16, 7, 7]
@@ -59,7 +59,7 @@ experiments:
           affine_conjugation: 
             __eval__: tune.choice([True, False])
           conditioner_cls: 
-            __class__: src.cjd_flows.networks.CondConvNet2D
+            __class__: cjd_flows.networks.CondConvNet2D
           conditioner_args:
             c_in: 16
             c_hidden: 
@@ -80,13 +80,13 @@ experiments:
           nonlinearity: 
             __eval__: tune.choice([torch.nn.ReLU()])
           base_distribution: 
-            __object__: src.cjd_flows.distributions.RadialDistribution       
+            __object__: cjd_flows.distributions.RadialDistribution       
             device: cuda
             p: 1.0
             loc: 
               __eval__: torch.zeros(16, 7, 7).to("cuda")
             norm_distribution:
-              __object__: src.cjd_flows.distributions.LogNormal
+              __object__: cjd_flows.distributions.LogNormal
               loc: 
                 __eval__: torch.zeros(1).to("cuda")
               scale: 

--- a/experiments/mnist/mnist_usflow_minimal.yaml
+++ b/experiments/mnist/mnist_usflow_minimal.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: mnist_ablation
 experiments:
   - &exp_laplace0
-    __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+    __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
     name: mnist0
     scheduler:  
       __object__: ray.tune.schedulers.ASHAScheduler
@@ -22,7 +22,7 @@ experiments:
         images: false
         image_shape: [28, 28]
       dataset: 
-        __object__: src.cjd_flows.explib.datasets.MnistSplit
+        __object__: cjd_flows.explib.datasets.MnistSplit
         space_to_depth_factor: 4
         device: cuda 
         digit: 0
@@ -40,7 +40,7 @@ experiments:
       
       model_cfg: 
         type:
-          __class__: src.cjd_flows.flows.USFlow
+          __class__: cjd_flows.flows.USFlow
         params:
           soft_training: true
           training_noise_prior:
@@ -53,7 +53,7 @@ experiments:
           lu_transform: 1
           householder: 1
           conditioner_cls: 
-            __class__: src.cjd_flows.networks.CondConvNet2D
+            __class__: cjd_flows.networks.CondConvNet2D
           conditioner_args:
             c_in: 16
             c_hidden: 32
@@ -67,13 +67,13 @@ experiments:
           nonlinearity: 
             __eval__: tune.choice([torch.nn.ReLU()])
           base_distribution: 
-            __object__: src.cjd_flows.distributions.RadialDistribution       
+            __object__: cjd_flows.distributions.RadialDistribution       
             device: cuda
             p: 1.0
             loc: 
               __eval__: torch.zeros([16, 7, 7]).to("cuda")
             norm_distribution:
-              __object__: src.cjd_flows.distributions.LogNormal
+              __object__: cjd_flows.distributions.LogNormal
               loc: 
                 __eval__: torch.ones([1]).to("cuda") * 4.5
               scale:
@@ -84,7 +84,7 @@ experiments:
     name: mnist1
     trial_config:
       dataset: 
-        __object__: src.cjd_flows.explib.datasets.MnistSplit
+        __object__: cjd_flows.explib.datasets.MnistSplit
         space_to_depth_factor: 4
         device: cuda 
         digit: 1
@@ -93,7 +93,7 @@ experiments:
     name: mnist2
     trial_config:
       dataset: 
-        __object__: src.cjd_flows.explib.datasets.MnistSplit
+        __object__: cjd_flows.explib.datasets.MnistSplit
         space_to_depth_factor: 4
         device: cuda 
         digit: 2
@@ -102,7 +102,7 @@ experiments:
     name: mnist3
     trial_config:
       dataset: 
-        __object__: src.cjd_flows.explib.datasets.MnistSplit
+        __object__: cjd_flows.explib.datasets.MnistSplit
         space_to_depth_factor: 4
         device: cuda 
         digit: 3
@@ -111,7 +111,7 @@ experiments:
     name: mnist4
     trial_config:
       dataset: 
-        __object__: src.cjd_flows.explib.datasets.MnistSplit
+        __object__: cjd_flows.explib.datasets.MnistSplit
         space_to_depth_factor: 4
         device: cuda 
         digit: 4
@@ -120,7 +120,7 @@ experiments:
     name: mnist5
     trial_config:
       dataset: 
-        __object__: src.cjd_flows.explib.datasets.MnistSplit
+        __object__: cjd_flows.explib.datasets.MnistSplit
         space_to_depth_factor: 4
         device: cuda 
         digit: 5
@@ -129,7 +129,7 @@ experiments:
     name: mnist6
     trial_config:
       dataset: 
-        __object__: src.cjd_flows.explib.datasets.MnistSplit
+        __object__: cjd_flows.explib.datasets.MnistSplit
         space_to_depth_factor: 4
         device: cuda 
         digit: 6
@@ -138,7 +138,7 @@ experiments:
     name: mnist7
     trial_config:
       dataset: 
-        __object__: src.cjd_flows.explib.datasets.MnistSplit
+        __object__: cjd_flows.explib.datasets.MnistSplit
         space_to_depth_factor: 4
         device: cuda 
         digit: 7
@@ -147,7 +147,7 @@ experiments:
     name: mnist8
     trial_config:
       dataset: 
-        __object__: src.cjd_flows.explib.datasets.MnistSplit
+        __object__: cjd_flows.explib.datasets.MnistSplit
         space_to_depth_factor: 4
         device: cuda 
         digit: 8
@@ -156,7 +156,7 @@ experiments:
     name: mnist9
     trial_config:
       dataset: 
-        __object__: src.cjd_flows.explib.datasets.MnistSplit
+        __object__: cjd_flows.explib.datasets.MnistSplit
         space_to_depth_factor: 4
         device: cuda 
         digit: 9

--- a/experiments/mnist/mnist_usflow_radial_mm_gpu.yaml
+++ b/experiments/mnist/mnist_usflow_radial_mm_gpu.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: mnist_ablation
 experiments:
   - &exp_laplace
-    __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+    __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
     name: mnist_full_laplace
     scheduler:  
       __object__: ray.tune.schedulers.ASHAScheduler
@@ -22,7 +22,7 @@ experiments:
         images: false
         image_shape: [28, 28]
       dataset: 
-        __object__: src.cjd_flows.explib.datasets.MnistSplit
+        __object__: cjd_flows.explib.datasets.MnistSplit
         space_to_depth_factor: 4
         device: cuda  # Options: [cpu, cuda] 
         digit: 0
@@ -40,7 +40,7 @@ experiments:
       
       model_cfg: 
         type:
-          __class__: src.cjd_flows.flows.USFlow
+          __class__: cjd_flows.flows.USFlow
         params:
           soft_training: true
           training_noise_prior:
@@ -53,7 +53,7 @@ experiments:
           lu_transform: 1
           householder: 1
           conditioner_cls: 
-            __class__: src.cjd_flows.networks.ConvNet2D
+            __class__: cjd_flows.networks.ConvNet2D
           conditioner_args:
             c_in: 16
             c_hidden: 64
@@ -66,11 +66,11 @@ experiments:
           nonlinearity: 
             __eval__: tune.choice([torch.nn.ReLU()])
           base_distribution: 
-            __object__: src.cjd_flows.distributions.RadialMM
+            __object__: cjd_flows.distributions.RadialMM
             loc: 
               __eval__: torch.randn([10, 16, 7, 7]).to("cuda")
             norm_distribution: 
-              __object__: src.cjd_flows.distributions.LogNormal
+              __object__: cjd_flows.distributions.LogNormal
               loc: 
                 __eval__: torch.zeros([10, 1, 1, 1]).to("cuda")
               scale:

--- a/experiments/synthetic/gaussian_mixture.yaml
+++ b/experiments/synthetic/gaussian_mixture.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: gaussian_mixture_experiments
 experiments:
   - &exp2d
-    __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+    __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
     name: gaussian_mixture_2D
     device: cpu
     scheduler: &scheduler 
@@ -23,10 +23,10 @@ experiments:
         "image_shape": [28, 28]
       dataset: &dataset
         class:
-          __class__: src.cjd_flows.explib.datasets.DistributionSplit
+          __class__: cjd_flows.explib.datasets.DistributionSplit
         params:
           distribution:
-            __object__: src.cjd_flows.distributions.GMM
+            __object__: cjd_flows.distributions.GMM
             loc:
               __eval__: torch.tensor([[-1.0, -1.0], [1.0, 1.0]]) 
             covariance_matrix:
@@ -42,14 +42,14 @@ experiments:
         __eval__: tune.choice([32])
       optim_cfg: &optim 
         optimizer:
-          __class__: src.cjd_flows.sophia.SophiaG
+          __class__: cjd_flows.sophia.SophiaG
         params:
           lr: 
             __eval__: 1e-3
           weight_decay: 0.0
       model_cfg:
         type:
-          __class__: src.cjd_flows.flows.USFlow
+          __class__: cjd_flows.flows.USFlow
         params:
           soft_training: 
             __eval__: tune.choice([False])
@@ -74,14 +74,14 @@ experiments:
           nonlinearity:
             __eval__: tune.choice([torch.nn.ReLU()])
           base_distribution:
-            __object__: src.cjd_flows.distributions.RadialDistribution
+            __object__: cjd_flows.distributions.RadialDistribution
             device: cpu
             p: 
               __eval__: float("1")
             loc:
               __eval__: torch.zeros([2]).to("cpu")
             norm_distribution:
-              __object__: src.cjd_flows.distributions.GammaMM
+              __object__: cjd_flows.distributions.GammaMM
               concentration:
                 __eval__: torch.rand([20]).to("cpu") * torch.sqrt(torch.tensor([2.0]))
               rate:
@@ -95,7 +95,7 @@ experiments:
       dataset:
         params:
           distribution:
-            __object__: src.cjd_flows.distributions.GMM
+            __object__: cjd_flows.distributions.GMM
             loc:
               __eval__: torch.tensor([[-1.0, -1.0, -1.0], [1.0, 1.0, 1.0]]) 
             covariance_matrix:
@@ -110,13 +110,13 @@ experiments:
             hidden_dims: [32, 32]
             param_dims: [3]
           base_distribution:
-            __object__: src.cjd_flows.distributions.RadialDistribution
+            __object__: cjd_flows.distributions.RadialDistribution
             p: 
               __eval__: float("1")
             loc:
               __eval__: torch.zeros([3]).to("cpu")
             norm_distribution:
-              __object__: src.cjd_flows.distributions.GammaMM
+              __object__: cjd_flows.distributions.GammaMM
               concentration:
                 __eval__: torch.rand([20]).to("cpu") * torch.sqrt(torch.tensor([3.0]))
               rate:
@@ -130,7 +130,7 @@ experiments:
       dataset:
         params:
           distribution:
-            __object__: src.cjd_flows.distributions.GMM
+            __object__: cjd_flows.distributions.GMM
             loc:
               __eval__: torch.tensor([[-1.0, -1.0, -1.0, -1.0], [1.0, 1.0, 1.0, 1.0]]) 
             covariance_matrix:
@@ -145,13 +145,13 @@ experiments:
             hidden_dims: [32, 32]
             param_dims: [4]
           base_distribution:
-            __object__: src.cjd_flows.distributions.RadialDistribution
+            __object__: cjd_flows.distributions.RadialDistribution
             p:
               __eval__: float("1")
             loc:
               __eval__: torch.zeros([4]).to("cpu")
             norm_distribution:
-              __object__: src.cjd_flows.distributions.GammaMM
+              __object__: cjd_flows.distributions.GammaMM
               concentration:
                 __eval__: torch.rand([20]).to("cpu") * torch.sqrt(torch.tensor([4.0]))
               rate:
@@ -165,7 +165,7 @@ experiments:
       dataset:
         params:
           distribution:
-            __object__: src.cjd_flows.distributions.GMM
+            __object__: cjd_flows.distributions.GMM
             loc:
               __eval__: torch.tensor([[-1.0, -1.0, -1.0, -1.0, -1.0], [1.0, 1.0, 1.0, 1.0, 1.0]]) 
             covariance_matrix:
@@ -180,13 +180,13 @@ experiments:
             hidden_dims: [32, 32]
             param_dims: [5]
           base_distribution:
-            __object__: src.cjd_flows.distributions.RadialDistribution
+            __object__: cjd_flows.distributions.RadialDistribution
             p:
               __eval__: float("1")
             loc:
               __eval__: torch.zeros([5]).to("cpu")
             norm_distribution:
-              __object__: src.cjd_flows.distributions.GammaMM
+              __object__: cjd_flows.distributions.GammaMM
               concentration:
                 __eval__: torch.rand([20]).to("cpu") * torch.sqrt(torch.tensor([5.0]))
               rate:
@@ -200,7 +200,7 @@ experiments:
       dataset:
         params:
           distribution:
-            __object__: src.cjd_flows.distributions.GMM
+            __object__: cjd_flows.distributions.GMM
             loc:
               __eval__: torch.tensor([[-1.0, -1.0, -1.0, -1.0, -1.0, -1.0], [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]]) 
             covariance_matrix:
@@ -215,13 +215,13 @@ experiments:
             hidden_dims: [32, 32]
             param_dims: [6]
           base_distribution:
-            __object__: src.cjd_flows.distributions.RadialDistribution
+            __object__: cjd_flows.distributions.RadialDistribution
             p:
               __eval__: float("1")
             loc:
               __eval__: torch.zeros([6]).to("cpu")
             norm_distribution:
-              __object__: src.cjd_flows.distributions.GammaMM
+              __object__: cjd_flows.distributions.GammaMM
               concentration:
                 __eval__: torch.rand([20]).to("cpu") * torch.sqrt(torch.tensor([6.0]))
               rate:
@@ -235,7 +235,7 @@ experiments:
       dataset:
         params:
           distribution:
-            __object__: src.cjd_flows.distributions.GMM
+            __object__: cjd_flows.distributions.GMM
             loc:
               __eval__: torch.tensor([[-1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0], [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]]) 
             covariance_matrix:
@@ -250,13 +250,13 @@ experiments:
             hidden_dims: [32, 32]
             param_dims: [7]
           base_distribution:
-            __object__: src.cjd_flows.distributions.RadialDistribution
+            __object__: cjd_flows.distributions.RadialDistribution
             p:
               __eval__: float("1")
             loc:
               __eval__: torch.zeros([7]).to("cpu")
             norm_distribution:
-              __object__: src.cjd_flows.distributions.GammaMM
+              __object__: cjd_flows.distributions.GammaMM
               concentration:
                 __eval__: torch.rand([20]).to("cpu") * torch.sqrt(torch.tensor([7.0]))
               rate:
@@ -270,7 +270,7 @@ experiments:
       dataset:
         params:
           distribution:
-            __object__: src.cjd_flows.distributions.GMM
+            __object__: cjd_flows.distributions.GMM
             loc:
               __eval__: torch.tensor([[-1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0], [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]]) 
             covariance_matrix:
@@ -285,13 +285,13 @@ experiments:
             hidden_dims: [32, 32]
             param_dims: [8]
           base_distribution:
-            __object__: src.cjd_flows.distributions.RadialDistribution
+            __object__: cjd_flows.distributions.RadialDistribution
             p:
               __eval__: float("1")
             loc:
               __eval__: torch.zeros([8]).to("cpu")
             norm_distribution:
-              __object__: src.cjd_flows.distributions.GammaMM
+              __object__: cjd_flows.distributions.GammaMM
               concentration:
                 __eval__: torch.rand([20]).to("cpu") * torch.sqrt(torch.tensor([8.0]))
               rate:
@@ -305,7 +305,7 @@ experiments:
       dataset:
         params:
           distribution:
-            __object__: src.cjd_flows.distributions.GMM
+            __object__: cjd_flows.distributions.GMM
             loc:
               __eval__: torch.tensor([[-1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0], [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]]) 
             covariance_matrix:
@@ -320,13 +320,13 @@ experiments:
             hidden_dims: [32, 32]
             param_dims: [9]
           base_distribution:
-            __object__: src.cjd_flows.distributions.RadialDistribution
+            __object__: cjd_flows.distributions.RadialDistribution
             p:
               __eval__: float("1")
             loc:
               __eval__: torch.zeros([9]).to("cpu")
             norm_distribution:
-              __object__: src.cjd_flows.distributions.GammaMM
+              __object__: cjd_flows.distributions.GammaMM
               concentration:
                 __eval__: torch.rand([20]).to("cpu") * torch.sqrt(torch.tensor([9.0]))
               rate:
@@ -340,7 +340,7 @@ experiments:
       dataset:
         params:
           distribution:
-            __object__: src.cjd_flows.distributions.GMM
+            __object__: cjd_flows.distributions.GMM
             loc:
               __eval__: torch.tensor([[-1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0], [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]]) 
             covariance_matrix:
@@ -355,13 +355,13 @@ experiments:
             hidden_dims: [32, 32]
             param_dims: [10]
           base_distribution:
-            __object__: src.cjd_flows.distributions.RadialDistribution
+            __object__: cjd_flows.distributions.RadialDistribution
             p:
               __eval__: float("1")
             loc:
               __eval__: torch.zeros([10]).to("cpu")
             norm_distribution:
-              __object__: src.cjd_flows.distributions.GammaMM
+              __object__: cjd_flows.distributions.GammaMM
               concentration:
                 __eval__: torch.rand([20]).to("cpu") * torch.sqrt(torch.tensor([10.0]))
               rate:
@@ -375,7 +375,7 @@ experiments:
       dataset:
         params:
           distribution:
-            __object__: src.cjd_flows.distributions.GMM
+            __object__: cjd_flows.distributions.GMM
             loc:
               __eval__: torch.tensor([[-1.0] * 100, [1.0] * 100]) 
             covariance_matrix:
@@ -390,13 +390,13 @@ experiments:
             hidden_dims: [32, 32]
             param_dims: [100]
           base_distribution:
-            __object__: src.cjd_flows.distributions.RadialDistribution
+            __object__: cjd_flows.distributions.RadialDistribution
             p:
               __eval__: float("1")
             loc:
               __eval__: torch.zeros([100]).to("cpu")
             norm_distribution:
-              __object__: src.cjd_flows.distributions.GammaMM
+              __object__: cjd_flows.distributions.GammaMM
               concentration:
                 __eval__: torch.rand([20]).to("cpu") * torch.sqrt(torch.tensor([100.0]))
               rate:

--- a/experiments/synthetic/gaussian_mixture_standart_base.yaml
+++ b/experiments/synthetic/gaussian_mixture_standart_base.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: gaussian_mixture_experiments
 experiments:
   - &exp2d
-    __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+    __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
     name: gaussian_mixture_2D
     device: cpu
     scheduler: &scheduler 
@@ -23,10 +23,10 @@ experiments:
         "image_shape": [28, 28]
       dataset: &dataset
         class:
-          __class__: src.cjd_flows.explib.datasets.DistributionSplit
+          __class__: cjd_flows.explib.datasets.DistributionSplit
         params:
           distribution:
-            __object__: src.cjd_flows.distributions.GMM
+            __object__: cjd_flows.distributions.GMM
             loc:
               __eval__: torch.tensor([[-1.0, -1.0], [1.0, 1.0]]) 
             covariance_matrix:
@@ -42,14 +42,14 @@ experiments:
         __eval__: tune.choice([32])
       optim_cfg: &optim 
         optimizer:
-          __class__: src.cjd_flows.sophia.SophiaG
+          __class__: cjd_flows.sophia.SophiaG
         params:
           lr: 
             __eval__: 1e-3
           weight_decay: 0.0
       model_cfg:
         type:
-          __class__: src.cjd_flows.flows.USFlow
+          __class__: cjd_flows.flows.USFlow
         params:
           soft_training: 
             __eval__: tune.choice([False])
@@ -74,7 +74,7 @@ experiments:
           nonlinearity:
             __eval__: tune.choice([torch.nn.ReLU()])
           base_distribution:
-            __object__: src.cjd_flows.distributions.Normal
+            __object__: cjd_flows.distributions.Normal
             loc:
               __eval__: torch.zeros([2]).to("cpu")
             scale:
@@ -86,7 +86,7 @@ experiments:
       dataset:
         params:
           distribution:
-            __object__: src.cjd_flows.distributions.GMM
+            __object__: cjd_flows.distributions.GMM
             loc:
               __eval__: torch.tensor([[-1.0, -1.0, -1.0], [1.0, 1.0, 1.0]]) 
             covariance_matrix:
@@ -101,7 +101,7 @@ experiments:
             hidden_dims: [32, 32]
             param_dims: [3]
           base_distribution:
-            __object__: src.cjd_flows.distributions.Normal
+            __object__: cjd_flows.distributions.Normal
             loc:
               __eval__: torch.zeros([3]).to("cpu")
   - __overwrites__: *exp2d
@@ -110,7 +110,7 @@ experiments:
       dataset:
         params:
           distribution:
-            __object__: src.cjd_flows.distributions.GMM
+            __object__: cjd_flows.distributions.GMM
             loc:
               __eval__: torch.tensor([[-1.0, -1.0, -1.0, -1.0], [1.0, 1.0, 1.0, 1.0]]) 
             covariance_matrix:
@@ -133,7 +133,7 @@ experiments:
       dataset:
         params:
           distribution:
-            __object__: src.cjd_flows.distributions.GMM
+            __object__: cjd_flows.distributions.GMM
             loc:
               __eval__: torch.tensor([[-1.0, -1.0, -1.0, -1.0, -1.0], [1.0, 1.0, 1.0, 1.0, 1.0]]) 
             covariance_matrix:
@@ -156,7 +156,7 @@ experiments:
       dataset:
         params:
           distribution:
-            __object__: src.cjd_flows.distributions.GMM
+            __object__: cjd_flows.distributions.GMM
             loc:
               __eval__: torch.tensor([[-1.0, -1.0, -1.0, -1.0, -1.0, -1.0], [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]]) 
             covariance_matrix:
@@ -179,7 +179,7 @@ experiments:
       dataset:
         params:
           distribution:
-            __object__: src.cjd_flows.distributions.GMM
+            __object__: cjd_flows.distributions.GMM
             loc:
               __eval__: torch.tensor([[-1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0], [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]]) 
             covariance_matrix:
@@ -202,7 +202,7 @@ experiments:
       dataset:
         params:
           distribution:
-            __object__: src.cjd_flows.distributions.GMM
+            __object__: cjd_flows.distributions.GMM
             loc:
               __eval__: torch.tensor([[-1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0], [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]]) 
             covariance_matrix:
@@ -225,7 +225,7 @@ experiments:
       dataset:
         params:
           distribution:
-            __object__: src.cjd_flows.distributions.GMM
+            __object__: cjd_flows.distributions.GMM
             loc:
               __eval__: torch.tensor([[-1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0], [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]]) 
             covariance_matrix:
@@ -248,7 +248,7 @@ experiments:
       dataset:
         params:
           distribution:
-            __object__: src.cjd_flows.distributions.GMM
+            __object__: cjd_flows.distributions.GMM
             loc:
               __eval__: torch.tensor([[-1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0], [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]]) 
             covariance_matrix:
@@ -271,7 +271,7 @@ experiments:
       dataset:
         params:
           distribution:
-            __object__: src.cjd_flows.distributions.GMM
+            __object__: cjd_flows.distributions.GMM
             loc:
               __eval__: torch.tensor([[-1.0] * 100, [1.0] * 100]) 
             covariance_matrix:

--- a/experiments/synthetic/synthetic.yaml
+++ b/experiments/synthetic/synthetic.yaml
@@ -1,14 +1,14 @@
 ---
 # Runs a series of experiments on various synthetic 2D datasets
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: synthetic_basedist_comparison
 experiments:
     - &main
-      __object__: src.cjd_flows.explib.base.ExperimentCollection
+      __object__: cjd_flows.explib.base.ExperimentCollection
       name: blobs
       experiments:
         - &main_normal
-          __object__:  src.cjd_flows.explib.hyperopt.HyperoptExperiment
+          __object__:  cjd_flows.explib.hyperopt.HyperoptExperiment
           name: normal
           scheduler: &scheduler 
             __object__: ray.tune.schedulers.ASHAScheduler
@@ -26,7 +26,7 @@ experiments:
               images: false
               scatter: true
             dataset: &dataset
-              __object__: src.cjd_flows.explib.datasets.SyntheticSplit
+              __object__: cjd_flows.explib.datasets.SyntheticSplit
               generator: circles
               params_train: &params_train
                 n_samples: 100000
@@ -48,7 +48,7 @@ experiments:
             
             model_cfg: 
               type:
-                __class__: &model src.cjd_flows.flows.NiceFlow
+                __class__: &model cjd_flows.flows.NiceFlow
               params:
                 soft_training: true
                 training_noise_prior:

--- a/experiments/synthetic/synthetic_rad_logN.yaml
+++ b/experiments/synthetic/synthetic_rad_logN.yaml
@@ -1,14 +1,14 @@
 ---
 # Runs a series of experiments on various synthetic 2D datasets
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: synthetic_basedist_comparison
 experiments:
     - &main
-      __object__: src.cjd_flows.explib.base.ExperimentCollection
+      __object__: cjd_flows.explib.base.ExperimentCollection
       name: blobs
       experiments:
         - &main_normal
-          __object__:  src.cjd_flows.explib.hyperopt.HyperoptExperiment
+          __object__:  cjd_flows.explib.hyperopt.HyperoptExperiment
           name: normal
           device: cpu
           skip: true
@@ -28,7 +28,7 @@ experiments:
               images: false
               scatter: true
             dataset: &dataset
-              __object__: src.cjd_flows.explib.datasets.SyntheticSplit
+              __object__: cjd_flows.explib.datasets.SyntheticSplit
               generator: circles
               params_train: &params_train
                 n_samples: 100000
@@ -50,7 +50,7 @@ experiments:
             
             model_cfg: 
               type:
-                __class__: &model src.cjd_flows.flows.NiceFlow
+                __class__: &model cjd_flows.flows.NiceFlow
               params:
                 soft_training: true
                 training_noise_prior:
@@ -67,7 +67,7 @@ experiments:
                   __eval__: tune.choice([torch.nn.ReLU()])
                 split_dim: &split_dim 1
                 base_distribution:
-                  __object__: src.cjd_flows.distributions.RadialDistribution       
+                  __object__: cjd_flows.distributions.RadialDistribution       
                   device: cpu
                   p: 1.0
                   loc: 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,12 +60,9 @@ Repository = "https://github.com/USFlows/cjd-flows"
 Documentation = "https://github.com/USFlows/cjd-flows/tree/main/docs"
 
 [tool.poetry]
-packages = [{include = "src/cjd_flows"}, {include = "scripts"}]
-
-#
-#[tool.setuptools.packages.find]
-#where = ["src"] 
-#
+# src-layout: installs as the top-level `cjd_flows` package.
+# The experiment runner scripts are repo tooling and are not shipped.
+packages = [{include = "cjd_flows", from = "src"}]
 
 
 [tool.poetry.group.dev]

--- a/scripts/eval.py
+++ b/scripts/eval.py
@@ -11,8 +11,8 @@ from scipy.stats import binomtest, wilcoxon
 from sklearn.neighbors import KernelDensity
 import pandas as pd
 
-from src.cjd_flows.explib.config_parser import from_checkpoint
-from src.cjd_flows.distributions import Independent
+from cjd_flows.explib.config_parser import from_checkpoint
+from cjd_flows.distributions import Independent
 import os
 import torch
 import numpy as np
@@ -567,7 +567,7 @@ if __name__ == '__main__':
         model = from_checkpoint(pkl_path, pt_path)
 
         # Load test set
-        from src.cjd_flows.explib.datasets import MnistDequantized
+        from cjd_flows.explib.datasets import MnistDequantized
         mnisti = MnistDequantized(dataloc="/home/faried/Projects/USFlows/data/mnist", space_to_depth_factor=4, digit=i, train=False)[:1000][0]
 
         evaluator = RadialFlowEvaluator(model, mnisti)

--- a/scripts/run-experiment.py
+++ b/scripts/run-experiment.py
@@ -3,7 +3,7 @@ import typing as T
 
 import click
 
-from src.cjd_flows.explib.config_parser import read_config
+from cjd_flows.explib.config_parser import read_config
 
 Pathable = T.Union[str, os.PathLike]  # In principle one can cast it to os.path.Path
 import torch 

--- a/src/cjd_flows/distributions.py
+++ b/src/cjd_flows/distributions.py
@@ -1,7 +1,7 @@
 from typing import Dict, Iterable, Optional, Union
-from src.cjd_flows.transforms import Rotation, CompositeRotation
-from src.cjd_flows.linalg import random_orthonormal_matrix
-from src.cjd_flows.utils import inv_softplus
+from cjd_flows.transforms import Rotation, CompositeRotation
+from cjd_flows.linalg import random_orthonormal_matrix
+from cjd_flows.utils import inv_softplus
 import pyro
 import math
 

--- a/src/cjd_flows/explib/eval.py
+++ b/src/cjd_flows/explib/eval.py
@@ -11,7 +11,7 @@ import scipy.stats as stats
 from scipy.stats import binomtest, wilcoxon
 from sklearn.neighbors import KernelDensity
 
-from src.cjd_flows.distributions import RadialDistribution
+from cjd_flows.distributions import RadialDistribution
 
 class RadialFlowEvaluator:
     def __init__(self, flow, data, device='cpu', p: Optional[float] = None, norm_distribution: Optional[torch.distributions.Distribution] = None, loc: Optional[torch.Tensor] = None):

--- a/src/cjd_flows/explib/hyperopt.py
+++ b/src/cjd_flows/explib/hyperopt.py
@@ -19,10 +19,10 @@ import ray
 from ray import tune
 from ray.air import RunConfig, session
 
-from src.cjd_flows.explib.base import Experiment
-from src.cjd_flows.explib.config_parser import from_checkpoint, create_objects_from_classes
-from src.cjd_flows.networks import AdditiveAffineNN
-from src.cjd_flows.transforms import ScaleTransform
+from cjd_flows.explib.base import Experiment
+from cjd_flows.explib.config_parser import from_checkpoint, create_objects_from_classes
+from cjd_flows.networks import AdditiveAffineNN
+from cjd_flows.transforms import ScaleTransform
 
 
 

--- a/src/cjd_flows/explib/visualization.py
+++ b/src/cjd_flows/explib/visualization.py
@@ -1,10 +1,10 @@
 from typing import Dict, Iterable, Literal
 from matplotlib import pyplot as plt
 import numpy as np
-from src.cjd_flows.explib import datasets
+from cjd_flows.explib import datasets
 import torch
 
-from src.cjd_flows.flows import Flow
+from cjd_flows.flows import Flow
 
 Norm = Literal[-1, 1, 2]
 SampleType = Literal["conditional", "boundary", "boundary_basis"]

--- a/src/cjd_flows/flows.py
+++ b/src/cjd_flows/flows.py
@@ -5,10 +5,10 @@ from torch.utils.data import Dataset
 from pyro import distributions as dist
 from typing import List, Dict, Literal, Any, Iterable, Optional, Type, Union, Tuple
 import torch
-from src.cjd_flows.distributions import RadialDistribution, Independent
-from src.cjd_flows.sophia import SophiaG
+from cjd_flows.distributions import RadialDistribution, Independent
+from cjd_flows.sophia import SophiaG
 
-from src.cjd_flows.transforms import (
+from cjd_flows.transforms import (
     ScaleTransform,
     MaskedCoupling,
     LUTransform,

--- a/src/cjd_flows/networks.py
+++ b/src/cjd_flows/networks.py
@@ -998,7 +998,7 @@ class JetConditioner(nn.Module):
     Kolesnikov et al. 2024).
 
     Shape-preserving network intended as the conditioner of a
-    :class:`~src.cjd_flows.transforms.MaskedCoupling` layer: since additive
+    :class:`~cjd_flows.transforms.MaskedCoupling` layer: since additive
     coupling has unit Jacobian determinant irrespective of the conditioner,
     arbitrary capacity (including global self-attention) can be spent here
     without affecting the constant-Jacobian-determinant property of the flow.

--- a/tests/cjd_flows/flows_test.py
+++ b/tests/cjd_flows/flows_test.py
@@ -1,8 +1,8 @@
 import torch
 from pyro.distributions import Normal
 
-from src.cjd_flows.flows import USFlow
-from src.cjd_flows.distributions import RadialDistribution, GammaMM
+from cjd_flows.flows import USFlow
+from cjd_flows.distributions import RadialDistribution, GammaMM
 from pyro.nn import DenseNN
 
 def test_onnx():

--- a/tests/cjd_flows/linalg_test.py
+++ b/tests/cjd_flows/linalg_test.py
@@ -1,5 +1,5 @@
 import torch
-from src.cjd_flows.linalg import solve_triangular
+from cjd_flows.linalg import solve_triangular
 
 test_size = 10
 tol =  1e-5

--- a/tests/cjd_flows/networks_test.py
+++ b/tests/cjd_flows/networks_test.py
@@ -1,7 +1,7 @@
 import torch
 
-from src.cjd_flows.networks import JetConditioner, sincos_pos_embed
-from src.cjd_flows.transforms import MaskedCoupling
+from cjd_flows.networks import JetConditioner, sincos_pos_embed
+from cjd_flows.transforms import MaskedCoupling
 
 
 def test_sincos_pos_embed():

--- a/tests/cjd_flows/transforms_test.py
+++ b/tests/cjd_flows/transforms_test.py
@@ -1,7 +1,7 @@
 import torch
 import math
 
-from src.cjd_flows.transforms import (
+from cjd_flows.transforms import (
     ScaleTransform,
     Permute,
     LUTransform,

--- a/tests/explib/hyperopt_test.py
+++ b/tests/explib/hyperopt_test.py
@@ -1,7 +1,7 @@
 import os
 import typing as T
 
-from src.cjd_flows.explib.config_parser import read_config
+from cjd_flows.explib.config_parser import read_config
 
 
 def test_mnist():

--- a/tests/explib/mnist.yaml
+++ b/tests/explib/mnist.yaml
@@ -1,9 +1,9 @@
 ---
-__object__: src.cjd_flows.explib.base.ExperimentCollection
+__object__: cjd_flows.explib.base.ExperimentCollection
 name: mnist_ablation_best_veriflow
 experiments:
   - &exp_laplace0
-    __object__: src.cjd_flows.explib.hyperopt.HyperoptExperiment
+    __object__: cjd_flows.explib.hyperopt.HyperoptExperiment
     name: mnist0
     scheduler:
       __object__: ray.tune.schedulers.ASHAScheduler
@@ -25,7 +25,7 @@ experiments:
         image_shape: [28, 28]
       dataset:
         class:
-          __class__: src.cjd_flows.explib.datasets.MnistSplit
+          __class__: cjd_flows.explib.datasets.MnistSplit
         params:
           dataloc: /home/faried/Projects/USFlows/data/mnist
           space_to_depth_factor: 4
@@ -35,14 +35,14 @@ experiments:
         __eval__: tune.choice([32])
       optim_cfg:
         optimizer:
-          __class__: src.cjd_flows.sophia.SophiaG
+          __class__: cjd_flows.sophia.SophiaG
         params:
           lr:
             __eval__: 1e-3
           weight_decay: 0.0
       model_cfg:
         type:
-          __class__: src.cjd_flows.flows.USFlow
+          __class__: cjd_flows.flows.USFlow
         params:
           soft_training: 
             __eval__: tune.choice([False])
@@ -57,7 +57,7 @@ experiments:
           lu_transform: 1
           householder: 1
           conditioner_cls:
-            __class__: src.cjd_flows.networks.ConvNet2D
+            __class__: cjd_flows.networks.ConvNet2D
           conditioner_args:
             c_in: 16
             c_hidden: 
@@ -76,14 +76,14 @@ experiments:
           nonlinearity:
             __eval__: tune.choice([torch.nn.ReLU()])
           base_distribution:
-            __object__: src.cjd_flows.distributions.RadialDistribution
+            __object__: cjd_flows.distributions.RadialDistribution
             device: cpu
             p: 
               __eval__: float("1")
             loc:
               __eval__: torch.zeros([16, 7, 7]).to("cpu")
             norm_distribution:
-              __object__: src.cjd_flows.distributions.GammaMM
+              __object__: cjd_flows.distributions.GammaMM
               concentration:
                 __eval__: torch.rand([50]).to("cpu") * 75
               rate:


### PR DESCRIPTION
The wheel previously installed generic top-level packages `src` and `scripts`, forcing `import src.cjd_flows` and inviting collisions. Switch to a proper src-layout so the package installs as `cjd_flows`, stop shipping the experiment runner scripts, and rewrite all `src.cjd_flows` module references to `cjd_flows` (code, tests, and experiment configs). Remove the obsolete src/__init__.py.

Verified: wheel contains only cjd_flows/, installs and imports in a fresh venv, full test suite passes against the editable install.